### PR TITLE
Codex/h264 low latency vui

### DIFF
--- a/External/Traffic/Source/MassTraffic/Private/MassTrafficChooseNextLaneProcessor.cpp
+++ b/External/Traffic/Source/MassTraffic/Private/MassTrafficChooseNextLaneProcessor.cpp
@@ -59,9 +59,7 @@ void UMassTrafficChooseNextLaneProcessor::ConfigureQueries(const TSharedRef<FMas
 	EntityQuery_Conditional.AddChunkRequirement<FMassSimulationVariableTickChunkFragment>(EMassFragmentAccess::ReadOnly);
 	EntityQuery_Conditional.SetChunkFilter(&FMassSimulationVariableTickChunkFragment::ShouldTickChunkThisFrame);
 	EntityQuery_Conditional.AddSubsystemRequirement<UMassTrafficSubsystem>(EMassFragmentAccess::ReadWrite);
-#if WITH_MASSTRAFFIC_DEBUG
 	EntityQuery_Conditional.AddSubsystemRequirement<UZoneGraphSubsystem>(EMassFragmentAccess::ReadOnly);
-#endif // WITH_MASSTRAFFIC_DEBUG
 }
 
 void UMassTrafficChooseNextLaneProcessor::Execute(FMassEntityManager& EntityManager, FMassExecutionContext& Context)
@@ -79,9 +77,7 @@ void UMassTrafficChooseNextLaneProcessor::Execute(FMassEntityManager& EntityMana
 #endif
 	{	
 		UMassTrafficSubsystem& MassTrafficSubsystem = QueryContext.GetMutableSubsystemChecked<UMassTrafficSubsystem>();
-#if WITH_MASSTRAFFIC_DEBUG
 		const UZoneGraphSubsystem& ZoneGraphSubsystem = QueryContext.GetSubsystemChecked<UZoneGraphSubsystem>();
-#endif // WITH_MASSTRAFFIC_DEBUG
 		const int32 NumEntities = QueryContext.GetNumEntities();
 		const TConstArrayView<FMassZoneGraphLaneLocationFragment> LaneLocationFragments = QueryContext.GetFragmentView<FMassZoneGraphLaneLocationFragment>();
 		const TConstArrayView<FAgentRadiusFragment> AgentRadiusFragments = QueryContext.GetFragmentView<FAgentRadiusFragment>();

--- a/Scripts/Package.sh
+++ b/Scripts/Package.sh
@@ -7,12 +7,18 @@ PROJECT_ROOT=$("$SCRIPT_DIR"/FindProjectRoot.sh)
 cd "$PROJECT_ROOT"
 PROJECT_NAME=$(find . -maxdepth 1 -name "*.uproject" -exec basename {} .uproject \;)
 
-# Check for low memory mode flag
+# Check for project packaging flags.
 LOW_MEMORY_MODE=false
+BUILD_CONFIGURATION=Development
 for arg in "$@"; do
-  if [[ "$arg" == "--low-memory" ]]; then
-    LOW_MEMORY_MODE=true
-  fi
+  case "$arg" in
+    --low-memory)
+      LOW_MEMORY_MODE=true
+      ;;
+    --release)
+      BUILD_CONFIGURATION=Shipping
+      ;;
+  esac
 done
 
 export UNREAL_ENGINE_PATH=$("$SCRIPT_DIR"/FindUnreal.sh)
@@ -83,7 +89,9 @@ fi
 cd "$UNREAL_ENGINE_PATH"
 
 # Build the base command with common arguments
-PACKAGE_COMMAND="Turnkey -command=VerifySdk -platform=$TARGET_PLATFORM -UpdateIfNeeded -project=\"$PROJECT_ROOT/$PROJECT_NAME.uproject\" BuildCookRun -nop4 -utf8output -nocompileeditor -skipbuildeditor -cook -target=\"$PROJECT_NAME\" -platform=$TARGET_PLATFORM -project=\"$PROJECT_ROOT/$PROJECT_NAME.uproject\" -installed -stage -package -pak -build -prereqs -clientconfig=Development"
+PACKAGE_COMMAND="Turnkey -command=VerifySdk -platform=$TARGET_PLATFORM -UpdateIfNeeded -project=\"$PROJECT_ROOT/$PROJECT_NAME.uproject\" BuildCookRun -nop4 -utf8output -nocompileeditor -skipbuildeditor -cook -target=\"$PROJECT_NAME\" -platform=$TARGET_PLATFORM -project=\"$PROJECT_ROOT/$PROJECT_NAME.uproject\" -installed -stage -package -pak -build -prereqs -clientconfig=$BUILD_CONFIGURATION"
+
+echo "Packaging $PROJECT_NAME in $BUILD_CONFIGURATION configuration -> $PROJECT_ROOT/Packaged"
 
 # Add platform-specific parts
 if [ "$HOST_PLATFORM" = "Win64" ]; then
@@ -104,16 +112,25 @@ fi
 
 # Add low memory options if requested
 if [ "$LOW_MEMORY_MODE" = "true" ]; then
-  PACKAGE_COMMAND="$PACKAGE_COMMAND -CookPartialGC -NoXGE -AdditionalCookerOptions=\"-cookprocesscount=1\""
-  echo "Low memory mode enabled: single cook process, partial GC, no XGE"
+  # The cooker and C++ build have independent concurrency controls. A single
+  # cook process alone does not prevent UBT/UBA from scheduling enough compiler
+  # actions to exhaust available memory on lower-memory machines. Three local
+  # actions leave headroom for UAT, the linker, and the cook commandlet while
+  # retaining useful parallelism.
+  PACKAGE_COMMAND="$PACKAGE_COMMAND -CookPartialGC -NoXGE -UbtArgs=\"-MaxParallelActions=3 -NoUBA -NoXGE\" -AdditionalCookerOptions=\"-cookprocesscount=1\""
+  echo "Low memory mode enabled: at most 3 compile actions, single cook process, partial GC, no UBA/XGE"
 fi
 
 # Filter out our custom flags before passing to UAT
 PASSTHROUGH_ARGS=()
 for arg in "$@"; do
-  if [[ "$arg" != "--low-memory" ]]; then
-    PASSTHROUGH_ARGS+=("$arg")
-  fi
+  case "$arg" in
+    --low-memory|--release)
+      ;;
+    *)
+      PASSTHROUGH_ARGS+=("$arg")
+      ;;
+  esac
 done
 
 # Execute the command with any additional arguments

--- a/Scripts/Package.sh
+++ b/Scripts/Package.sh
@@ -10,6 +10,7 @@ PROJECT_NAME=$(find . -maxdepth 1 -name "*.uproject" -exec basename {} .uproject
 # Check for project packaging flags.
 LOW_MEMORY_MODE=false
 BUILD_CONFIGURATION=Development
+PACKAGE_VARIANT=Development
 for arg in "$@"; do
   case "$arg" in
     --low-memory)
@@ -17,9 +18,11 @@ for arg in "$@"; do
       ;;
     --release)
       BUILD_CONFIGURATION=Shipping
+      PACKAGE_VARIANT=Release
       ;;
   esac
 done
+PACKAGE_OUTPUT_DIR="$PROJECT_ROOT/Packaged/$PACKAGE_VARIANT"
 
 export UNREAL_ENGINE_PATH=$("$SCRIPT_DIR"/FindUnreal.sh)
 
@@ -91,15 +94,15 @@ cd "$UNREAL_ENGINE_PATH"
 # Build the base command with common arguments
 PACKAGE_COMMAND="Turnkey -command=VerifySdk -platform=$TARGET_PLATFORM -UpdateIfNeeded -project=\"$PROJECT_ROOT/$PROJECT_NAME.uproject\" BuildCookRun -nop4 -utf8output -nocompileeditor -skipbuildeditor -cook -target=\"$PROJECT_NAME\" -platform=$TARGET_PLATFORM -project=\"$PROJECT_ROOT/$PROJECT_NAME.uproject\" -installed -stage -package -pak -build -prereqs -clientconfig=$BUILD_CONFIGURATION"
 
-echo "Packaging $PROJECT_NAME in $BUILD_CONFIGURATION configuration -> $PROJECT_ROOT/Packaged"
+echo "Packaging $PROJECT_NAME in $BUILD_CONFIGURATION configuration -> $PACKAGE_OUTPUT_DIR"
 
 # Add platform-specific parts
 if [ "$HOST_PLATFORM" = "Win64" ]; then
-  PACKAGE_COMMAND="./Engine/Build/BatchFiles/RunUAT.bat $PACKAGE_COMMAND -unrealexe=\"UnrealEditor-Cmd.exe\" -stagingdirectory=\"$PROJECT_ROOT/Packaged\""
+  PACKAGE_COMMAND="./Engine/Build/BatchFiles/RunUAT.bat $PACKAGE_COMMAND -unrealexe=\"UnrealEditor-Cmd.exe\" -stagingdirectory=\"$PACKAGE_OUTPUT_DIR\""
 elif [ "$HOST_PLATFORM" = "Mac" ]; then
-  PACKAGE_COMMAND="./Engine/Build/BatchFiles/RunUAT.sh $PACKAGE_COMMAND -unrealexe=\"UnrealEditor-Cmd\" -archive -archivedirectory=\"$PROJECT_ROOT/Packaged\""
+  PACKAGE_COMMAND="./Engine/Build/BatchFiles/RunUAT.sh $PACKAGE_COMMAND -unrealexe=\"UnrealEditor-Cmd\" -archive -archivedirectory=\"$PACKAGE_OUTPUT_DIR\""
 elif [ "$HOST_PLATFORM" = "Linux" ]; then
-  PACKAGE_COMMAND="./Engine/Build/BatchFiles/RunUAT.sh $PACKAGE_COMMAND -unrealexe=\"UnrealEditor\" -stagingdirectory=\"$PROJECT_ROOT/Packaged\""
+  PACKAGE_COMMAND="./Engine/Build/BatchFiles/RunUAT.sh $PACKAGE_COMMAND -unrealexe=\"UnrealEditor\" -stagingdirectory=\"$PACKAGE_OUTPUT_DIR\""
 else
   echo "Unsupported platform"
   exit 1
@@ -137,15 +140,16 @@ done
 eval "$PACKAGE_COMMAND" "${PASSTHROUGH_ARGS[@]}"
 
 # Copy cook metadata (including chunk manifests) to the package directory
+mkdir -p "$PACKAGE_OUTPUT_DIR"
 if [[ "$TARGET_PLATFORM" = "Win64" ]]; then
-  cp -r "$PROJECT_ROOT/Saved/Cooked/Windows/$PROJECT_NAME/Metadata" "$PROJECT_ROOT/Packaged"
-  cp -r "$PROJECT_ROOT/Saved/Cooked/Windows/$PROJECT_NAME/AssetRegistry.bin" "$PROJECT_ROOT/Packaged"
+  cp -r "$PROJECT_ROOT/Saved/Cooked/Windows/$PROJECT_NAME/Metadata" "$PACKAGE_OUTPUT_DIR"
+  cp -r "$PROJECT_ROOT/Saved/Cooked/Windows/$PROJECT_NAME/AssetRegistry.bin" "$PACKAGE_OUTPUT_DIR"
 else
-  cp -r "$PROJECT_ROOT/Saved/Cooked/$TARGET_PLATFORM/$PROJECT_NAME/Metadata" "$PROJECT_ROOT/Packaged"
-  cp -r "$PROJECT_ROOT/Saved/Cooked/$TARGET_PLATFORM/$PROJECT_NAME/AssetRegistry.bin" "$PROJECT_ROOT/Packaged"
+  cp -r "$PROJECT_ROOT/Saved/Cooked/$TARGET_PLATFORM/$PROJECT_NAME/Metadata" "$PACKAGE_OUTPUT_DIR"
+  cp -r "$PROJECT_ROOT/Saved/Cooked/$TARGET_PLATFORM/$PROJECT_NAME/AssetRegistry.bin" "$PACKAGE_OUTPUT_DIR"
 fi
 
-# Copy generated Rust crate(s) to Packaged/API/Rust/ so downstream consumers can
+# Copy generated Rust crate(s) to the variant's API/Rust/ so downstream consumers can
 # build a Rust client against this packaged build. Only ships the files that
 # `cargo package` would include — same as the publish artifact, minus target/,
 # Cargo.lock, tempo_proto_includes/, etc. Source of truth is each crate's
@@ -160,7 +164,7 @@ PACKAGE_RUST_CRATE() {
   # POSIX [[:space:]] (not \s — BSD/macOS sed doesn't support \s and would leave the value as the
   # whole `name = "..."` line, creating a directory with spaces in its name).
   CRATE_NAME=$(grep -m1 '^name' "$CRATE_MANIFEST" | sed -E 's/^name[[:space:]]*=[[:space:]]*"([^"]+)".*/\1/')
-  local DEST="$PROJECT_ROOT/Packaged/API/Rust/$CRATE_NAME"
+  local DEST="$PACKAGE_OUTPUT_DIR/API/Rust/$CRATE_NAME"
   echo "Packaging Rust crate $CRATE_NAME -> $DEST"
   # `--no-verify` skips the compile-the-extracted-crate step, so this works
   # even when a path dep (e.g. tempo-sim) isn't on crates.io yet. Capture the
@@ -197,7 +201,7 @@ if [[ -n "$TEMPO_GEN_RUST_API" && "$TEMPO_GEN_RUST_API" != "0" ]]; then
 fi
 
 # Build the generated Python package(s) (sdist + wheel) into
-# Packaged/API/Python/<dist-name>/ so downstream consumers can `pip install` a
+# the variant's API/Python/<dist-name>/ so downstream consumers can `pip install` a
 # Python client against this packaged build. Mirrors PACKAGE_RUST_CRATE.
 PYTHON_BIN=""
 # Prefer Tempo's managed venv (TempoEnv, created by the build's GenAPI step). It has the build
@@ -223,7 +227,7 @@ PACKAGE_PYTHON_PACKAGE() {
   # POSIX [[:space:]] (not \s — BSD/macOS sed doesn't support \s and would leave the value as the
   # whole `name = "..."` line, creating a directory with spaces in its name).
   DIST_NAME=$(grep -m1 '^name' "$PYPROJECT" | sed -E 's/^name[[:space:]]*=[[:space:]]*"([^"]+)".*/\1/')
-  local DEST="$PROJECT_ROOT/Packaged/API/Python/$DIST_NAME"
+  local DEST="$PACKAGE_OUTPUT_DIR/API/Python/$DIST_NAME"
   echo "Packaging Python package $DIST_NAME -> $DEST"
   rm -rf "$DEST"
   mkdir -p "$DEST"

--- a/TempoAgents/Source/TempoAgents/Public/TempoBrightnessTranslator.h
+++ b/TempoAgents/Source/TempoAgents/Public/TempoBrightnessTranslator.h
@@ -5,6 +5,7 @@
 #include "TempoBrightnessMeterComponent.h"
 
 #include "MassCommonFragments.h"
+#include "MassEntityQuery.h"
 #include "MassTranslator.h"
 
 #include "TempoBrightnessTranslator.generated.h"

--- a/TempoAgents/Source/TempoAgents/Public/TempoMassAgentSyncTraits.h
+++ b/TempoAgents/Source/TempoAgents/Public/TempoMassAgentSyncTraits.h
@@ -5,6 +5,7 @@
 #include "CoreMinimal.h"
 #include "MassAgentTraits.h"
 #include "MassCommonFragments.h"
+#include "MassEntityQuery.h"
 #include "MassEntityTraitBase.h"
 
 #include "TempoMassAgentSyncTraits.generated.h"

--- a/TempoSensors/README.md
+++ b/TempoSensors/README.md
@@ -65,6 +65,8 @@ Cameras expose a `Video` measurement alongside `ColorImage`. Subscribe via `Vide
 
 The encoder is created lazily on first request and reopens automatically when resolution or any per-request parameter changes. Multiple subscribers to the same camera share one encoder — every subscriber receives the same encoded bytes — so adding clients is cheap, but they all share the same bitrate / KFI / profile (last writer wins on reconfigure).
 
+Tempo requests Unreal's ultra-low-latency encoder mode and normalizes SPS NAL units that omit VUI bitstream restrictions. The added restriction declares zero frame reordering and bounds the decoded-picture buffer to the stream's reference-frame requirement, preventing hardware decoders from conservatively rebuffering after every IDR. SPS units that already contain VUI are preserved unchanged.
+
 Python clients use `tempo_sim.TempoImageUtils.stream_video_images(...)` (PyAV decoder); Rust clients see the wiring in `ExampleClients/Rust/SensorPlayground` (ffmpeg-next decoder, requires FFmpeg 8 dev headers locally for the `ffmpeg-next` build). C++ client decode is not yet provided.
 
 ### Configure a Lidar

--- a/TempoSensors/Source/TempoSensors/Private/TempoCameraVideoEncoder.cpp
+++ b/TempoSensors/Source/TempoSensors/Private/TempoCameraVideoEncoder.cpp
@@ -2,6 +2,8 @@
 
 #include "TempoCameraVideoEncoder.h"
 
+#include "TempoH264SPS.h"
+
 #include "TempoSensors.h"
 
 #include "AVDevice.h"
@@ -332,6 +334,11 @@ void FTempoCameraVideoEncoder::EncodeRenderTarget_RenderThread(UTextureRenderTar
 
 	if (bGotAny)
 	{
+		// AVCodecs' low-latency setting configures the encoder backend, but some backends omit the
+		// H.264 VUI bitstream restriction. Hardware decoders may then rebuild a conservatively-sized
+		// decoded-picture buffer after every IDR, producing a visible pause. Advertise the actual
+		// zero-reorder, one-reference-frame stream semantics in-band for every joining client.
+		TempoH264::AddLowLatencyVUI(Aggregate.Data);
 		Aggregate.Width = Impl->AppliedConfig.Width;
 		Aggregate.Height = Impl->AppliedConfig.Height;
 		Aggregate.CaptureTime = CaptureTime;

--- a/TempoSensors/Source/TempoSensors/Private/TempoH264SPS.cpp
+++ b/TempoSensors/Source/TempoSensors/Private/TempoH264SPS.cpp
@@ -1,0 +1,399 @@
+// Copyright Tempo Simulation, LLC. All Rights Reserved
+
+#include "TempoH264SPS.h"
+
+namespace
+{
+	class FBitReader
+	{
+	public:
+		explicit FBitReader(const TArray<uint8>& InData)
+			: Data(InData)
+		{
+		}
+
+		bool ReadBit(bool& Out)
+		{
+			uint32 Value = 0;
+			if (!ReadBits(1, Value))
+			{
+				return false;
+			}
+			Out = Value != 0;
+			return true;
+		}
+
+		bool ReadBits(uint32 Count, uint32& Out)
+		{
+			if (Count > 32 || BitPosition + Count > static_cast<uint64>(Data.Num()) * 8)
+			{
+				return false;
+			}
+			Out = 0;
+			for (uint32 Index = 0; Index < Count; ++Index)
+			{
+				Out = (Out << 1) | ((Data[BitPosition / 8] >> (7 - BitPosition % 8)) & 1);
+				++BitPosition;
+			}
+			return true;
+		}
+
+		bool ReadUE(uint32& Out)
+		{
+			uint32 LeadingZeroBits = 0;
+			bool Bit = false;
+			while (true)
+			{
+				if (!ReadBit(Bit))
+				{
+					return false;
+				}
+				if (Bit)
+				{
+					break;
+				}
+				if (++LeadingZeroBits > 31)
+				{
+					return false;
+				}
+			}
+
+			uint32 Suffix = 0;
+			if (LeadingZeroBits > 0 && !ReadBits(LeadingZeroBits, Suffix))
+			{
+				return false;
+			}
+			Out = ((1u << LeadingZeroBits) - 1) + Suffix;
+			return true;
+		}
+
+		bool ReadSE(int32& Out)
+		{
+			uint32 CodeNum = 0;
+			if (!ReadUE(CodeNum))
+			{
+				return false;
+			}
+			Out = (CodeNum & 1) != 0 ? static_cast<int32>((CodeNum + 1) / 2) : -static_cast<int32>(CodeNum / 2);
+			return true;
+		}
+
+		uint64 GetBitPosition() const
+		{
+			return BitPosition;
+		}
+
+	private:
+		const TArray<uint8>& Data;
+		uint64 BitPosition = 0;
+	};
+
+	class FBitWriter
+	{
+	public:
+		void WriteBit(bool Value)
+		{
+			if (BitPosition % 8 == 0)
+			{
+				Data.Add(0);
+			}
+			if (Value)
+			{
+				Data.Last() |= static_cast<uint8>(1u << (7 - BitPosition % 8));
+			}
+			++BitPosition;
+		}
+
+		void WriteUE(uint32 Value)
+		{
+			const uint32 CodeNum = Value + 1;
+			uint32 NumBits = 0;
+			for (uint32 Remaining = CodeNum; Remaining > 0; Remaining >>= 1)
+			{
+				++NumBits;
+			}
+			for (uint32 Index = 1; Index < NumBits; ++Index)
+			{
+				WriteBit(false);
+			}
+			for (int32 Index = static_cast<int32>(NumBits) - 1; Index >= 0; --Index)
+			{
+				WriteBit(((CodeNum >> Index) & 1) != 0);
+			}
+		}
+
+		const TArray<uint8>& GetData() const
+		{
+			return Data;
+		}
+
+	private:
+		TArray<uint8> Data;
+		uint64 BitPosition = 0;
+	};
+
+	bool SkipScalingList(FBitReader& Reader, uint32 Size)
+	{
+		int32 LastScale = 8;
+		int32 NextScale = 8;
+		for (uint32 Index = 0; Index < Size; ++Index)
+		{
+			if (NextScale != 0)
+			{
+				int32 DeltaScale = 0;
+				if (!Reader.ReadSE(DeltaScale))
+				{
+					return false;
+				}
+				NextScale = (LastScale + DeltaScale + 256) % 256;
+			}
+			LastScale = NextScale == 0 ? LastScale : NextScale;
+		}
+		return true;
+	}
+
+	bool FindVUIFlag(const TArray<uint8>& RBSP, uint64& OutBitPosition, uint32& OutMaxNumRefFrames, bool& OutVUIAlreadyPresent)
+	{
+		FBitReader Reader(RBSP);
+		uint32 ProfileIdc = 0;
+		uint32 Ignored = 0;
+		if (!Reader.ReadBits(8, ProfileIdc) || !Reader.ReadBits(8, Ignored) || !Reader.ReadBits(8, Ignored) || !Reader.ReadUE(Ignored))
+		{
+			return false;
+		}
+
+		if (ProfileIdc == 100 || ProfileIdc == 110 || ProfileIdc == 122 || ProfileIdc == 244 ||
+			ProfileIdc == 44 || ProfileIdc == 83 || ProfileIdc == 86 || ProfileIdc == 118 ||
+			ProfileIdc == 128 || ProfileIdc == 138 || ProfileIdc == 139 || ProfileIdc == 134 || ProfileIdc == 135)
+		{
+			uint32 ChromaFormatIdc = 0;
+			if (!Reader.ReadUE(ChromaFormatIdc))
+			{
+				return false;
+			}
+			bool Flag = false;
+			if (ChromaFormatIdc == 3 && !Reader.ReadBit(Flag))
+			{
+				return false;
+			}
+			if (!Reader.ReadUE(Ignored) || !Reader.ReadUE(Ignored) || !Reader.ReadBit(Flag) || !Reader.ReadBit(Flag))
+			{
+				return false;
+			}
+			if (Flag)
+			{
+				const uint32 ScalingListCount = ChromaFormatIdc == 3 ? 12 : 8;
+				for (uint32 Index = 0; Index < ScalingListCount; ++Index)
+				{
+					if (!Reader.ReadBit(Flag))
+					{
+						return false;
+					}
+					if (Flag && !SkipScalingList(Reader, Index < 6 ? 16 : 64))
+					{
+						return false;
+					}
+				}
+			}
+		}
+
+		uint32 PicOrderCntType = 0;
+		if (!Reader.ReadUE(Ignored) || !Reader.ReadUE(PicOrderCntType))
+		{
+			return false;
+		}
+		if (PicOrderCntType == 0)
+		{
+			if (!Reader.ReadUE(Ignored))
+			{
+				return false;
+			}
+		}
+		else if (PicOrderCntType == 1)
+		{
+			bool Flag = false;
+			int32 SignedIgnored = 0;
+			uint32 CycleLength = 0;
+			if (!Reader.ReadBit(Flag) || !Reader.ReadSE(SignedIgnored) || !Reader.ReadSE(SignedIgnored) || !Reader.ReadUE(CycleLength))
+			{
+				return false;
+			}
+			for (uint32 Index = 0; Index < CycleLength; ++Index)
+			{
+				if (!Reader.ReadSE(SignedIgnored))
+				{
+					return false;
+				}
+			}
+		}
+
+		bool Flag = false;
+		if (!Reader.ReadUE(OutMaxNumRefFrames) || !Reader.ReadBit(Flag) || !Reader.ReadUE(Ignored) || !Reader.ReadUE(Ignored) || !Reader.ReadBit(Flag))
+		{
+			return false;
+		}
+		if (!Flag && !Reader.ReadBit(Flag))
+		{
+			return false;
+		}
+		if (!Reader.ReadBit(Flag) || !Reader.ReadBit(Flag))
+		{
+			return false;
+		}
+		if (Flag)
+		{
+			for (uint32 Index = 0; Index < 4; ++Index)
+			{
+				if (!Reader.ReadUE(Ignored))
+				{
+					return false;
+				}
+			}
+		}
+
+		OutBitPosition = Reader.GetBitPosition();
+		return Reader.ReadBit(OutVUIAlreadyPresent);
+	}
+
+	TArray<uint8> EBSPToRBSP(const uint8* Data, int32 Size)
+	{
+		TArray<uint8> Result;
+		Result.Reserve(Size);
+		for (int32 Index = 0; Index < Size; ++Index)
+		{
+			if (Index >= 2 && Index + 1 < Size
+				&& Data[Index] == 3 && Data[Index - 1] == 0 && Data[Index - 2] == 0
+				&& Data[Index + 1] <= 3)
+			{
+				continue;
+			}
+			Result.Add(Data[Index]);
+		}
+		return Result;
+	}
+
+	TArray<uint8> RBSPToEBSP(const TArray<uint8>& RBSP)
+	{
+		TArray<uint8> Result;
+		Result.Reserve(RBSP.Num() + RBSP.Num() / 16);
+		for (uint8 Byte : RBSP)
+		{
+			if (Result.Num() >= 2 && Result[Result.Num() - 1] == 0 && Result[Result.Num() - 2] == 0 && Byte <= 3)
+			{
+				Result.Add(3);
+			}
+			Result.Add(Byte);
+		}
+		return Result;
+	}
+
+	bool RewriteSPS(const uint8* Data, int32 Size, TArray<uint8>& Out)
+	{
+		if (Size < 2 || (Data[0] & 0x1f) != 7)
+		{
+			return false;
+		}
+
+		const TArray<uint8> RBSP = EBSPToRBSP(Data + 1, Size - 1);
+		uint64 VUIFlagPosition = 0;
+		uint32 MaxNumRefFrames = 0;
+		bool bVUIAlreadyPresent = false;
+		if (!FindVUIFlag(RBSP, VUIFlagPosition, MaxNumRefFrames, bVUIAlreadyPresent) || bVUIAlreadyPresent)
+		{
+			return false;
+		}
+
+		FBitWriter Writer;
+		for (uint64 BitIndex = 0; BitIndex < VUIFlagPosition; ++BitIndex)
+		{
+			Writer.WriteBit(((RBSP[BitIndex / 8] >> (7 - BitIndex % 8)) & 1) != 0);
+		}
+
+		Writer.WriteBit(true);  // vui_parameters_present_flag
+		Writer.WriteBit(false); // aspect_ratio_info_present_flag
+		Writer.WriteBit(false); // overscan_info_present_flag
+		Writer.WriteBit(false); // video_signal_type_present_flag
+		Writer.WriteBit(false); // chroma_loc_info_present_flag
+		Writer.WriteBit(false); // timing_info_present_flag
+		Writer.WriteBit(false); // nal_hrd_parameters_present_flag
+		Writer.WriteBit(false); // vcl_hrd_parameters_present_flag
+		Writer.WriteBit(false); // pic_struct_present_flag
+		Writer.WriteBit(true);  // bitstream_restriction_flag
+		Writer.WriteBit(true);  // motion_vectors_over_pic_boundaries_flag
+		Writer.WriteUE(0);      // max_bytes_per_pic_denom
+		Writer.WriteUE(0);      // max_bits_per_mb_denom
+		Writer.WriteUE(16);     // log2_max_mv_length_horizontal
+		Writer.WriteUE(16);     // log2_max_mv_length_vertical
+		Writer.WriteUE(0);      // max_num_reorder_frames
+		Writer.WriteUE(FMath::Max(1u, MaxNumRefFrames)); // max_dec_frame_buffering
+		Writer.WriteBit(true);  // rbsp_stop_one_bit; zero padding is already present
+
+		Out.Reset();
+		Out.Add(Data[0]);
+		Out.Append(RBSPToEBSP(Writer.GetData()));
+		return true;
+	}
+
+	int32 FindStartCode(const TArray<uint8>& Data, int32 From, int32& OutPrefixSize)
+	{
+		for (int32 Index = From; Index + 3 <= Data.Num(); ++Index)
+		{
+			if (Data[Index] != 0 || Data[Index + 1] != 0)
+			{
+				continue;
+			}
+			if (Data[Index + 2] == 1)
+			{
+				OutPrefixSize = 3;
+				return Index;
+			}
+			if (Index + 3 < Data.Num() && Data[Index + 2] == 0 && Data[Index + 3] == 1)
+			{
+				OutPrefixSize = 4;
+				return Index;
+			}
+		}
+		return INDEX_NONE;
+	}
+}
+
+bool TempoH264::AddLowLatencyVUI(TArray<uint8>& AnnexBAccessUnit)
+{
+	TArray<uint8> Result;
+	int32 Cursor = 0;
+	bool bRewritten = false;
+	while (Cursor < AnnexBAccessUnit.Num())
+	{
+		int32 PrefixSize = 0;
+		const int32 StartCode = FindStartCode(AnnexBAccessUnit, Cursor, PrefixSize);
+		if (StartCode == INDEX_NONE)
+		{
+			Result.Append(AnnexBAccessUnit.GetData() + Cursor, AnnexBAccessUnit.Num() - Cursor);
+			break;
+		}
+
+		const int32 NALStart = StartCode + PrefixSize;
+		int32 NextPrefixSize = 0;
+		const int32 NextStartCode = FindStartCode(AnnexBAccessUnit, NALStart, NextPrefixSize);
+		const int32 NALEnd = NextStartCode == INDEX_NONE ? AnnexBAccessUnit.Num() : NextStartCode;
+		Result.Append(AnnexBAccessUnit.GetData() + Cursor, NALStart - Cursor);
+
+		TArray<uint8> RewrittenSPS;
+		if (RewriteSPS(AnnexBAccessUnit.GetData() + NALStart, NALEnd - NALStart, RewrittenSPS))
+		{
+			Result.Append(RewrittenSPS);
+			bRewritten = true;
+		}
+		else
+		{
+			Result.Append(AnnexBAccessUnit.GetData() + NALStart, NALEnd - NALStart);
+		}
+		Cursor = NALEnd;
+	}
+
+	if (bRewritten)
+	{
+		AnnexBAccessUnit = MoveTemp(Result);
+	}
+	return bRewritten;
+}

--- a/TempoSensors/Source/TempoSensors/Private/TempoH264SPS.h
+++ b/TempoSensors/Source/TempoSensors/Private/TempoH264SPS.h
@@ -1,0 +1,13 @@
+// Copyright Tempo Simulation, LLC. All Rights Reserved
+
+#pragma once
+
+#include "CoreMinimal.h"
+
+namespace TempoH264
+{
+	// Adds an H.264 VUI bitstream restriction to SPS NAL units that do not already carry VUI.
+	// Returns true when at least one SPS was rewritten. The restriction declares zero frame
+	// reordering and bounds the decoded-picture buffer to the SPS reference-frame requirement.
+	bool AddLowLatencyVUI(TArray<uint8>& AnnexBAccessUnit);
+}

--- a/TempoSensors/Source/TempoSensors/Private/Tests/TempoH264SPSTest.cpp
+++ b/TempoSensors/Source/TempoSensors/Private/Tests/TempoH264SPSTest.cpp
@@ -1,0 +1,61 @@
+// Copyright Tempo Simulation, LLC. All Rights Reserved
+
+#if WITH_DEV_AUTOMATION_TESTS
+
+#include "TempoH264SPS.h"
+
+#include "Misc/AutomationTest.h"
+
+IMPLEMENT_SIMPLE_AUTOMATION_TEST(
+	FTempoH264AddsLowLatencyVUITest,
+	"Tempo.Sensors.Video.H264AddsLowLatencyVUI",
+	EAutomationTestFlags::EditorContext | EAutomationTestFlags::EngineFilter)
+
+bool FTempoH264AddsLowLatencyVUITest::RunTest(const FString& Parameters)
+{
+	TArray<uint8> AccessUnit = {
+		0x00, 0x00, 0x00, 0x01,
+		0x27, 0x42, 0x00, 0x1f, 0xab, 0x40, 0x78, 0x08, 0xbf, 0x68,
+		0x00, 0x00, 0x00, 0x01,
+		0x28, 0xce, 0x3c, 0x80,
+	};
+	const TArray<uint8> Expected = {
+		0x00, 0x00, 0x00, 0x01,
+		0x27, 0x42, 0x00, 0x1f, 0xab, 0x40, 0x78, 0x08, 0xbf, 0x70, 0x0f, 0x08, 0x84, 0x6a,
+		0x00, 0x00, 0x00, 0x01,
+		0x28, 0xce, 0x3c, 0x80,
+	};
+
+	TestTrue(TEXT("SPS without VUI is rewritten"), TempoH264::AddLowLatencyVUI(AccessUnit));
+	TestTrue(TEXT("Access unit contains the low-latency VUI and preserves the PPS"), AccessUnit == Expected);
+	TestFalse(TEXT("Already-rewritten SPS is left unchanged"), TempoH264::AddLowLatencyVUI(AccessUnit));
+	TestTrue(TEXT("Second pass is byte-stable"), AccessUnit == Expected);
+
+	TArray<uint8> ThreeByteStartCodes = {
+		0x00, 0x00, 0x01,
+		0x27, 0x42, 0x00, 0x1f, 0xab, 0x40, 0x78, 0x08, 0xbf, 0x68,
+		0x00, 0x00, 0x01,
+		0x28, 0xce, 0x3c, 0x80,
+	};
+	const TArray<uint8> ExpectedThreeByteStartCodes = {
+		0x00, 0x00, 0x01,
+		0x27, 0x42, 0x00, 0x1f, 0xab, 0x40, 0x78, 0x08, 0xbf, 0x70, 0x0f, 0x08, 0x84, 0x6a,
+		0x00, 0x00, 0x01,
+		0x28, 0xce, 0x3c, 0x80,
+	};
+	TestTrue(TEXT("Three-byte Annex-B start codes are supported"), TempoH264::AddLowLatencyVUI(ThreeByteStartCodes));
+	TestTrue(TEXT("Three-byte start codes and PPS are preserved"), ThreeByteStartCodes == ExpectedThreeByteStartCodes);
+
+	TArray<uint8> DeltaFrame = {0x00, 0x00, 0x00, 0x01, 0x21, 0x9a, 0x20};
+	const TArray<uint8> OriginalDeltaFrame = DeltaFrame;
+	TestFalse(TEXT("Access units without an SPS are not rewritten"), TempoH264::AddLowLatencyVUI(DeltaFrame));
+	TestTrue(TEXT("Access units without an SPS remain byte-stable"), DeltaFrame == OriginalDeltaFrame);
+
+	TArray<uint8> TruncatedSPS = {0x00, 0x00, 0x00, 0x01, 0x27, 0x42};
+	const TArray<uint8> OriginalTruncatedSPS = TruncatedSPS;
+	TestFalse(TEXT("A truncated SPS is rejected"), TempoH264::AddLowLatencyVUI(TruncatedSPS));
+	TestTrue(TEXT("A truncated SPS remains byte-stable"), TruncatedSPS == OriginalTruncatedSPS);
+	return true;
+}
+
+#endif


### PR DESCRIPTION
<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR adds low-latency H.264 SPS handling and updates packaging behavior. The main changes are:

- Adds SPS parsing and VUI bitstream restriction insertion for video packets.
- Applies the H.264 rewrite in the camera video encoder path.
- Adds tests and README notes for the low-latency video behavior.
- Adds release packaging flags, variant output folders, and low-memory build arguments.
- Makes MassTraffic ZoneGraph subsystem access unconditional.
- Adds explicit Mass entity query includes.

<h3>Confidence Score: 4/5</h3>

The package layout change needs a compatibility fix before merging.

- Default Unix packaging now writes artifacts one level deeper than existing packaged-test consumers expect.
- The H.264 rewrite path appears consistent with the inspected Annex-B encoder flow.
- The MassTraffic subsystem change matches existing module and runtime dependencies.

Scripts/Package.sh

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| Scripts/Package.sh | Adds release and development package variants, but the new default output root can break existing packaged-test consumers. |
| TempoSensors/Source/TempoSensors/Private/TempoH264SPS.cpp | Adds Annex-B SPS parsing and VUI insertion for SPS units that do not already contain VUI. |
| TempoSensors/Source/TempoSensors/Private/TempoCameraVideoEncoder.cpp | Runs the low-latency H.264 SPS normalization on encoded video aggregates before enqueueing them. |
| External/Traffic/Source/MassTraffic/Private/MassTrafficChooseNextLaneProcessor.cpp | Makes the ZoneGraph subsystem requirement and access match existing non-debug MassTraffic usage. |
| TempoAgents/Source/TempoAgents/Public/TempoBrightnessTranslator.h | Adds an explicit MassEntityQuery include. |
| TempoAgents/Source/TempoAgents/Public/TempoMassAgentSyncTraits.h | Adds an explicit MassEntityQuery include. |

<a href="https://app.greptile.com/ide/claude-code?prompt=Fix%20the%20following%201%20code%20review%20issue.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%201%0AScripts%2FPackage.sh%3A95%0A**Default%20Package%20Root%20Moves**%0A%0ADefault%20Linux%2FMac%20packaging%20now%20stages%20into%20%60Packaged%2FDevelopment%60%2C%20but%20the%20existing%20packaged-test%20path%20still%20treats%20%60Packaged%60%20as%20the%20root%20and%20looks%20for%20platform%20binaries%20and%20API%20artifacts%20directly%20under%20it.%20A%20normal%20package-and-test%20run%20can%20upload%20%60Packaged%2FDevelopment%2F...%60%20and%20then%20fail%20to%20find%20%60Packaged%2FLinux%2F*.sh%60%20or%20the%20expected%20metadata%2FAPI%20paths%20after%20download.%0A%0A&repo=aurum-ai%2Ftempo&pr=5&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaudeDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=6"><img alt="Fix All in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=6"></picture></a> <a href="https://app.greptile.com/api/ide/codex?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22aurum-ai%2Ftempo%22%20on%20the%20existing%20branch%20%22codex%2Fh264-low-latency-vui%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22codex%2Fh264-low-latency-vui%22.%0A%0AFix%20the%20following%201%20code%20review%20issue.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%201%0AScripts%2FPackage.sh%3A95%0A**Default%20Package%20Root%20Moves**%0A%0ADefault%20Linux%2FMac%20packaging%20now%20stages%20into%20%60Packaged%2FDevelopment%60%2C%20but%20the%20existing%20packaged-test%20path%20still%20treats%20%60Packaged%60%20as%20the%20root%20and%20looks%20for%20platform%20binaries%20and%20API%20artifacts%20directly%20under%20it.%20A%20normal%20package-and-test%20run%20can%20upload%20%60Packaged%2FDevelopment%2F...%60%20and%20then%20fail%20to%20find%20%60Packaged%2FLinux%2F*.sh%60%20or%20the%20expected%20metadata%2FAPI%20paths%20after%20download.%0A%0A&repo=aurum-ai%2Ftempo&pr=5&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodexDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=6"><img alt="Fix All in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=6"></picture></a>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 1 code review issue. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 1
Scripts/Package.sh:95
**Default Package Root Moves**

Default Linux/Mac packaging now stages into `Packaged/Development`, but the existing packaged-test path still treats `Packaged` as the root and looks for platform binaries and API artifacts directly under it. A normal package-and-test run can upload `Packaged/Development/...` and then fail to find `Packaged/Linux/*.sh` or the expected metadata/API paths after download.

`````

</details>

<sub>Reviews (1): Last reviewed commit: ["Fix H.264 hardware decoder rebuffering"](https://github.com/aurum-ai/tempo/commit/dad18a17c027537f7ffc7cbf7c9bac4cb2f93089) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=43399348)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->